### PR TITLE
chore: 실시간 캔들 테스트 및 구현,tooltip은 css때매 실패

### DIFF
--- a/.api/api.json
+++ b/.api/api.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "apis": [
+    {
+      "identifier": "upbit",
+      "source": "@upbit/v1.4.4#1h2zv2al3jq48nm",
+      "integrity": "sha512-1BiJDhnGQXmbCE/xTjJc7siCHP+KU2qnjdRxVbO4PqZ9+ItBuiZ7AWl+57tkjsD1UX6SFF4w3RhMEmP7mZIYDQ==",
+      "installerVersion": "6.1.1"
+    }
+  ]
+}

--- a/.api/apis/upbit/openapi.json
+++ b/.api/apis/upbit/openapi.json
@@ -1,0 +1,23 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BaseUrl",
+    "version": "unknown"
+  },
+  "servers": [
+    {
+      "url": "https://api.upbit.com/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {}
+  },
+  "security": [
+    {}
+  ],
+  "paths": {},
+  "x-readme": {
+    "headers": []
+  },
+  "x-readme-fauxas": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bit-voyage",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.6.8",
         "lightweight-charts": "^4.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -3048,8 +3049,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
@@ -3101,6 +3101,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3490,7 +3500,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3834,7 +3843,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4736,6 +4744,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4765,7 +4792,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6331,7 +6357,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6340,7 +6365,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -7273,6 +7297,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "axios": "^1.6.8",
     "lightweight-charts": "^4.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/App-Ex.tsx
+++ b/src/App-Ex.tsx
@@ -1,0 +1,259 @@
+import axios from 'axios'; // HTTP 요청을 위해 axios를 가져옵니다.
+import React, { useEffect, useRef } from 'react';
+import { createChart } from 'lightweight-charts';
+
+//하드코딩된 업비트 분캔들 response를 lightweight-charts에 연결 테스트
+interface UpbitCandle {
+  market: string;
+  candle_date_time_utc: string;
+  opening_price: number;
+  high_price: number;
+  low_price: number;
+  trade_price: number;
+  timestamp: number;
+  candle_acc_trade_price: number;
+  candle_acc_trade_volume: number;
+  unit: number;
+}
+/*
+// Hardcoded data array
+const data: UpbitCandle[] = [
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T05:00:00',
+    opening_price: 95385000,
+    high_price: 95500000,
+    low_price: 95210000,
+    trade_price: 95210000,
+    timestamp: 1713679199649,
+    candle_acc_trade_price: 5662004340.05579,
+    candle_acc_trade_volume: 59.36954697,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T06:00:00',
+    opening_price: 95213000,
+    high_price: 95460000,
+    low_price: 95120000,
+    trade_price: 95230000,
+    timestamp: 1713682798017,
+    candle_acc_trade_price: 7690354527.12303,
+    candle_acc_trade_volume: 80.70167268,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T07:00:00',
+    opening_price: 95235000,
+    high_price: 95309000,
+    low_price: 95000000,
+    trade_price: 95250000,
+    timestamp: 1713686399671,
+    candle_acc_trade_price: 11639306840.51962,
+    candle_acc_trade_volume: 122.33718961,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T08:00:00',
+    opening_price: 95250000,
+    high_price: 95400000,
+    low_price: 94944000,
+    trade_price: 94944000,
+    timestamp: 1713689999107,
+    candle_acc_trade_price: 9957928361.93603,
+    candle_acc_trade_volume: 104.68674247,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T09:00:00',
+    opening_price: 94942000,
+    high_price: 95000000,
+    low_price: 94622000,
+    trade_price: 94903000,
+    timestamp: 1713693599977,
+    candle_acc_trade_price: 13963034149.43408,
+    candle_acc_trade_volume: 147.27755886,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T10:00:00',
+    opening_price: 94903000,
+    high_price: 94990000,
+    low_price: 94549000,
+    trade_price: 94853000,
+    timestamp: 1713697199206,
+    candle_acc_trade_price: 14911361444.09317,
+    candle_acc_trade_volume: 157.38345045,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T11:00:00',
+    opening_price: 94849000,
+    high_price: 95485000,
+    low_price: 94827000,
+    trade_price: 95420000,
+    timestamp: 1713700797318,
+    candle_acc_trade_price: 16109661422.40164,
+    candle_acc_trade_volume: 169.12329111,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T12:00:00',
+    opening_price: 95329000,
+    high_price: 95520000,
+    low_price: 94910000,
+    trade_price: 94998000,
+    timestamp: 1713704399412,
+    candle_acc_trade_price: 12407876311.58096,
+    candle_acc_trade_volume: 130.24680872,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T13:00:00',
+    opening_price: 94998000,
+    high_price: 95412000,
+    low_price: 94793000,
+    trade_price: 94866000,
+    timestamp: 1713707999609,
+    candle_acc_trade_price: 10816360034.52755,
+    candle_acc_trade_volume: 113.77984311,
+    unit: 60,
+  },
+  {
+    market: 'KRW-BTC',
+    candle_date_time_utc: '2024-04-21T14:00:00',
+    opening_price: 94855000,
+    high_price: 95000000,
+    low_price: 94844000,
+    trade_price: 94846000,
+    timestamp: 1713711043743,
+    candle_acc_trade_price: 4602189190.86122,
+    candle_acc_trade_volume: 48.48780662,
+    unit: 60,
+  },
+];
+
+// const App: React.FC = () => {
+//   const chartContainerRef = useRef<HTMLDivElement>(null); // Reference to the div where the chart will be rendered
+
+//   useEffect(() => {
+//     if (chartContainerRef.current) {
+//       // Ensures the div is mounted before attempting to create a chart
+//       const chart = createChart(chartContainerRef.current, {
+//         width: 700,
+//         height: 400,
+//       }); // Creates the chart with specified dimensions
+//       const candleSeries = chart.addCandlestickSeries(); // Adds a candlestick series to the chart
+//       //Maps over the data array to format it for the candlestick series
+//       const chartData = data.map(candle => ({
+//         //이렇게 할지 일자 데이터가 제대로 안들어가 빈화면이 표시가 됨.
+//         //time: candle.candle_date_time_utc as unknown as Time, // Converts UTC string to Time type (make sure to handle time conversion appropriately)
+//         time: Math.floor(
+//           new Date(candle.candle_date_time_utc).getTime() / 1000
+//         ),
+//         open: candle.opening_price,
+//         high: candle.high_price,
+//         low: candle.low_price,
+//         close: candle.trade_price,
+//       }));
+//       candleSeries.setData(chartData); // Sets the formatted data to the series
+//     }
+//   }, []);
+
+//   return <div ref={chartContainerRef} />; // Renders a div that will contain the chart
+// };
+// export default App;
+*/
+
+const App: React.FC = () => {
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (chartContainerRef.current) {
+        const chart = createChart(chartContainerRef.current, {
+          width: 700,
+          height: 400,
+        });
+        const candleSeries = chart.addCandlestickSeries();
+
+        try {
+          const response = await axios.get(
+            'https://api.upbit.com/v1/candles/minutes/60?market=KRW-BTC&count=10'
+          );
+          console.log('API Response:', response.data); // API 응답 로그
+
+          const chartData = response.data
+            .map((candle: UpbitCandle) => ({
+              time: Math.floor(
+                new Date(candle.candle_date_time_utc).getTime() / 1000
+              ),
+              open: candle.opening_price,
+              high: candle.high_price,
+              low: candle.low_price,
+              close: candle.trade_price,
+            }))
+            .sort((a, b) => a.time - b.time); // 시간 순으로 데이터 정렬
+
+          candleSeries.setData(chartData);
+        } catch (error) {
+          console.error('Error fetching data:', error);
+        }
+      }
+    };
+
+    fetchData(); // fetchData 함수 실행
+  }, []);
+
+  return <div ref={chartContainerRef} />;
+};
+
+export default App;
+
+// import { createChart } from 'lightweight-charts';
+// import './App.css'; // TradingView의 lightweight-charts 라이브러리에서 createChart를 가져옵니다.
+
+// interface CoinoneTrade {
+//   timestamp: string; // Coinone에서 거래 항목의 구조를 정의합니다.
+//   price: string;
+// }
+
+// const App: React.FC = () => {
+//   const chartContainerRef = React.useRef<HTMLDivElement>(null); // 차트가 렌더링될 div 요소를 담을 ref를 생성합니다.
+
+//   useEffect(() => {
+//     // 컴포넌트가 마운트될 때 데이터를 가져오고 차트를 설정하기 위해 useEffect를 사용합니다.
+//     if (chartContainerRef.current) {
+//       // ref가 요소에 연결되었는지 확인합니다.
+//       const chart = createChart(chartContainerRef.current, {
+//         width: 800,
+//         height: 600,
+//       }); // 지정된 크기로 차트를 초기화합니다.
+//       const lineSeries = chart.addLineSeries(); // 데이터를 나타낼 선 시리즈를 추가합니다.
+
+//       axios.get('https://api.coinone.co.kr/trades/?currency=BTC') // Coinone에서 BTC에 대한 거래 데이터를 가져옵니다.
+//         .then(response => {
+//           const data = response.data.completeOrders as CoinoneTrade[]; // 응답에서 거래 데이터를 추출합니다.
+//           const chartData = data.map(trade => ({
+//             time: trade.timestamp as unknown as number, // TradingView에서 필요한 형식으로 데이터를 매핑하고, 타임스탬프를 변환합니다.
+//             value: parseFloat(trade.price), // 문자열 가격을 부동 소수점 숫자로 변환합니다.
+//           }));
+//           lineSeries.setData(chartData); // 차트의 선 시리즈에 형식화된 데이터를 설정합니다.
+//         })
+//         .catch(error => console.error('Coinone 데이터 가져오기 오류:', error)); // 요청이 실패하면 오류를 로그합니다.
+//     }
+//   }, []); // 빈 의존성 배열은 이 효과가 초기 렌더링 후 한 번만 실행되도록 보장합니다.
+
+//   return (
+//     <div ref={chartContainerRef} /> // TradingView 차트를 포함할 div를 렌더링합니다.
+//   );
+// };
+
+// export default App; // 다른 애플리케이션 부분에서 사용할 수 있도록 컴포넌트를 내보냅니다.

--- a/src/App-sample.tsx
+++ b/src/App-sample.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import './App.css';
+
+//TradingView 위젯 테스트
+function App() {
+  useEffect(() => {
+    // TradingView 위젯 스크립트를 동적으로 추가합니다.
+    const script = document.createElement('script');
+    script.src =
+      'https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js';
+    script.async = true;
+    script.innerHTML = JSON.stringify({
+      symbol: 'NASDAQ:AAPL', // 표시하고 싶은 주식 심볼
+      width: '100%',
+      height: '100%',
+      locale: 'kr', // 언어 설정 (한국어)
+      dateRange: '24M', // 날짜 범위
+      colorTheme: 'light', // 테마 색상
+      trendLineColor: 'rgba(41, 98, 255, 1)',
+      underLineColor: 'rgba(41, 98, 255, 0.3)',
+      isTransparent: false,
+      autosize: true,
+      largeChartUrl: '',
+    });
+    document.body.appendChild(script);
+
+    return () => {
+      // 컴포넌트 언마운트 시 스크립트 제거
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <>
+      <div id="tradingview-widget-container">
+        <div className="tradingview-widget-container__widget"></div>
+      </div>
+    </>
+  );
+}
+
+export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,116 @@
-import './App.css';
+import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { createChart, IChartApi, ISeriesApi } from 'lightweight-charts';
 
-function App() {
-  return (
-    <>
-      <p className="text-3xl font-bold underline">테스트</p>
-    </>
-  );
+interface UpbitCandle {
+  market: string;
+  candle_date_time_utc: string;
+  opening_price: number;
+  high_price: number;
+  low_price: number;
+  trade_price: number;
+  timestamp: number;
 }
+
+const App: React.FC = () => {
+  const [unit, setUnit] = useState('minute'); // 'minute', 'hour', 'day', 'month'
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+
+  useEffect(() => {
+    if (chartContainerRef.current && !chartRef.current) {
+      chartRef.current = createChart(chartContainerRef.current, {
+        width: 700,
+        height: 600,
+      });
+      candleSeriesRef.current = chartRef.current.addCandlestickSeries({
+        priceLineVisible: true,
+        lastValueVisible: true,
+        priceFormat: {
+          type: 'price',
+          precision: 0,
+          minMove: 0.01,
+        },
+      });
+      setupTooltip(chartRef.current, candleSeriesRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!candleSeriesRef.current) return;
+
+      const urlParams = {
+        minute: { url: 'minutes/1', count: 60 }, // 분 데이터
+        hour: { url: 'minutes/60', count: 48 }, // 시간 데이터
+        day: { url: 'days', count: 30 }, // 일 데이터
+        month: { url: 'months', count: 12 }, // 월 데이터
+      };
+
+      const selectedParam = urlParams[unit];
+
+      try {
+        const response = await axios.get(
+          `https://api.upbit.com/v1/candles/${selectedParam.url}?market=KRW-BTC&count=${selectedParam.count}`
+        );
+        const sortedData = response.data
+          .map((candle: UpbitCandle) => ({
+            time: Math.floor(
+              new Date(candle.candle_date_time_utc).getTime() / 1000
+            ),
+            open: candle.opening_price,
+            high: candle.high_price,
+            low: candle.low_price,
+            close: candle.trade_price,
+          }))
+          .sort((a: { time: number }, b: { time: number }) => a.time - b.time);
+
+        candleSeriesRef.current.setData(sortedData);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchData();
+  }, [unit]);
+
+  function setupTooltip(chart: IChartApi, series: ISeriesApi<'Candlestick'>) {
+    const tooltip = document.createElement('div');
+    tooltip.className = 'floating-tooltip';
+    document.body.appendChild(tooltip);
+    chart.subscribeCrosshairMove(function (param) {
+      if (
+        !param.time ||
+        param.point === undefined ||
+        !param.seriesPrices.get(series)
+      ) {
+        tooltip.style.display = 'none';
+      } else {
+        const priceData = param.seriesPrices.get(series);
+        tooltip.innerHTML = `
+          Date: ${new Date(param.time * 1000).toLocaleString()}<br>
+          Open: ${priceData.open}<br>
+          High: ${priceData.high}<br>
+          Low: ${priceData.low}<br>
+          Close: ${priceData.close}
+        `;
+        tooltip.style.display = 'block';
+        tooltip.style.left = `${Math.min(param.point.x + 20, window.innerWidth - tooltip.offsetWidth)}px`; // 화면 밖으로 나가지 않도록 조정
+        tooltip.style.top = `${Math.min(param.point.y + 20, window.innerHeight - tooltip.offsetHeight)}px`; // 화면 밖으로 나가지 않도록 조정
+      }
+    });
+  }
+
+  return (
+    <div>
+      <div ref={chartContainerRef} />
+      <button onClick={() => setUnit('minute')}>분</button>
+      <button onClick={() => setUnit('hour')}>시간</button>
+      <button onClick={() => setUnit('day')}>일</button>
+      <button onClick={() => setUnit('month')}>월</button>
+    </div>
+  );
+};
 
 export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+ :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -70,3 +70,27 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.floating-tooltip {
+  position: absolute;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  border-radius: 5px;
+  pointer-events: none; /* 마우스 이벤트가 툴팁을 통과하도록 설정 */
+  z-index: 100;
+  display: none; /* 기본적으로 숨김 */
+}
+
+
+/* body {
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+} */
+


### PR DESCRIPTION
chore: TradingView 보고 몇개 따라해보고 구현한거랑 테스트용 몇개 올려둡니다.

 - App.tsx : 캔들 뷰, 월/일/시간/분 토글가능, tooltip(css수정필요)
 - App-Ex : 간단 예제로 trading view test용
 - App-Sample : 업비트 분캔들 response를 하드코딩으로 lightweight차트에 때려박은거

전체적으로 axios(api 통신)랑 lightweight-charts(차트) 라이브러리 추가 필요
npm install axios 
npm install --save lightweight-charts
tooltip을 보이게 하려면 전체 css를 수정해야되는듯합니다.

새로알게된것은 commit시, "chore : 이러쿵"(X), chore: 저러쿵(O) 👍 